### PR TITLE
Suppress annoying hydrogen dummy atom warnings

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -306,6 +306,7 @@ struct RGroupDecompData {
     }
 
     if (params.removeHydrogensPostMatch) {
+      RDLog::BlockLogs blocker;
       bool implicitOnly = false;
       bool updateExplicitCount = false;
       bool sanitize = false;


### PR DESCRIPTION
Since we are making some fixes, this will suppress the annoying not removing hydrogens attached to dummy atoms.